### PR TITLE
Overrides of `hashCode`

### DIFF
--- a/src/main/java/com/winner_is_kungen/tda367/model/ComponentUpdateRecord.java
+++ b/src/main/java/com/winner_is_kungen/tda367/model/ComponentUpdateRecord.java
@@ -24,7 +24,7 @@ public class ComponentUpdateRecord {
 		}
 		else if (other instanceof ComponentUpdateRecord) {
 			ComponentUpdateRecord otherRecord = (ComponentUpdateRecord)other;
-			return componentID.equals(otherRecord.getComponentID()) && channel == otherRecord.getChannel();
+			return getComponentID().equals(otherRecord.getComponentID()) && getChannel() == otherRecord.getChannel();
 		}
 		else {
 			return false;

--- a/src/main/java/com/winner_is_kungen/tda367/model/ComponentUpdateRecord.java
+++ b/src/main/java/com/winner_is_kungen/tda367/model/ComponentUpdateRecord.java
@@ -30,4 +30,9 @@ public class ComponentUpdateRecord {
 			return false;
 		}
 	}
+
+	@Override
+	public int hashCode() {
+		return getComponentID().hashCode() + getChannel();
+	}
 }

--- a/src/main/java/com/winner_is_kungen/tda367/model/util/ConnectionRecord.java
+++ b/src/main/java/com/winner_is_kungen/tda367/model/util/ConnectionRecord.java
@@ -69,4 +69,9 @@ public class ConnectionRecord<L extends ComponentListener> {
 		ConnectionRecord p = (ConnectionRecord) obj;         // True if both components of the two Pairs are equal
 		return this.getListener().equals(p.getListener()) && this.getInputChannel() == p.getInputChannel() && this.getOutputChannel() == p.getOutputChannel();
 	}
+
+	@Override
+	public int hashCode() {
+		return getListener().hashCode() + getInputChannel() + getOutputChannel();
+	}
 }


### PR DESCRIPTION
I ran PDM (a code analyzing tool) and the only complaint it had were that we should have overrides of `hashCode` whenever we override `equals`.